### PR TITLE
[user] GET /getUser 내부서비스만 호출 가능하도록 인증 추가

### DIFF
--- a/user/src/main/java/kr/flab/momukji/user/controller/UserController.java
+++ b/user/src/main/java/kr/flab/momukji/user/controller/UserController.java
@@ -5,7 +5,6 @@ import javax.validation.Valid;
 import kr.flab.momukji.user.dto.request.GetUserDto;
 import kr.flab.momukji.user.dto.request.UserDto;
 import kr.flab.momukji.user.dto.response.common.CommonResponse;
-import kr.flab.momukji.user.entity.User;
 import kr.flab.momukji.user.service.UserService;
 
 import org.springframework.http.ResponseEntity;
@@ -30,7 +29,7 @@ public class UserController {
     }
 
     @GetMapping("/getUser")
-    public User getUser(@RequestBody GetUserDto userDto) {
-        return userService.getUser(userDto.getEmail());
+    public CommonResponse getUser(@RequestBody GetUserDto userDto) {
+        return userService.getUser(userDto);
     }
 }

--- a/user/src/main/java/kr/flab/momukji/user/dto/request/GetUserDto.java
+++ b/user/src/main/java/kr/flab/momukji/user/dto/request/GetUserDto.java
@@ -9,4 +9,5 @@ import lombok.*;
 @NoArgsConstructor
 public class GetUserDto {
     private String email;
+    private String authCode;
 }

--- a/user/src/main/java/kr/flab/momukji/user/dto/response/common/CommonResponse.java
+++ b/user/src/main/java/kr/flab/momukji/user/dto/response/common/CommonResponse.java
@@ -1,3 +1,4 @@
+
 package kr.flab.momukji.user.dto.response.common;
 
 import lombok.AllArgsConstructor;

--- a/user/src/main/java/kr/flab/momukji/user/dto/response/common/ResultCode.java
+++ b/user/src/main/java/kr/flab/momukji/user/dto/response/common/ResultCode.java
@@ -7,7 +7,9 @@ public enum ResultCode {
     SUCCESS("성공"),
     DUPLICATED_EMAIL("중복된 이메일"),
     INVALID_STORE_ID("유효하지 않은 상점 ID"), INVALID_PRODUCT_ID("유효하지 않은 상품 ID"),
-    INVALID_ORDER_ID("유효하지 않은 주문 ID");
+    INVALID_ORDER_ID("유효하지 않은 주문 ID"),
+    EMAIL_NOT_EXIST("존재하지 않는 아이디"),
+    INVALID_AUTH_CODE("유효하지 않은 AUTH_CODE");
     
     private final String message;
 

--- a/user/src/main/java/kr/flab/momukji/user/dto/response/common/UserResponse.java
+++ b/user/src/main/java/kr/flab/momukji/user/dto/response/common/UserResponse.java
@@ -1,0 +1,14 @@
+package kr.flab.momukji.user.dto.response.common;
+
+import kr.flab.momukji.user.entity.User;
+import lombok.Getter;
+
+@Getter
+public class UserResponse extends CommonResponse {
+    private User user;
+
+    public UserResponse(User user) {
+        this.resultCode = ResultCode.SUCCESS;
+        this.user = user;
+    }
+}

--- a/user/src/main/java/kr/flab/momukji/user/service/UserService.java
+++ b/user/src/main/java/kr/flab/momukji/user/service/UserService.java
@@ -1,14 +1,18 @@
 package kr.flab.momukji.user.service;
 
 import java.util.Collections;
+import java.util.Optional;
 
+import kr.flab.momukji.user.dto.request.GetUserDto;
 import kr.flab.momukji.user.dto.request.UserDto;
 import kr.flab.momukji.user.dto.response.common.CommonResponse;
 import kr.flab.momukji.user.dto.response.common.ResultCode;
+import kr.flab.momukji.user.dto.response.common.UserResponse;
 import kr.flab.momukji.user.entity.Authority;
 import kr.flab.momukji.user.entity.User;
 import kr.flab.momukji.user.repository.UserRepository;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,6 +24,9 @@ import lombok.RequiredArgsConstructor;
 public class UserService {
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
+
+    @Value("${momukji.user.authCode}")
+    private String authCode;
 
     @Transactional
     public CommonResponse signup(UserDto userDto) {
@@ -50,7 +57,16 @@ public class UserService {
         return userRepository.findOneWithAuthoritiesByEmail(email).orElse(null);
     }
 
-    public User getUser(String email) {
-        return userRepository.findOneWithAuthoritiesByEmail(email).orElse(null);
+    public CommonResponse getUser(GetUserDto userDto) {
+        if (!userDto.getAuthCode().equals(authCode)) {
+            return new CommonResponse(ResultCode.INVALID_AUTH_CODE);
+        }
+
+        Optional<User> optUser = userRepository.findOneWithAuthoritiesByEmail(userDto.getEmail());
+        if (optUser.isEmpty()) {
+            return new CommonResponse(ResultCode.EMAIL_NOT_EXIST);
+        }
+
+        return new UserResponse(optUser.get());
     }
 }

--- a/user/src/main/resources/META-INF/spring-configuration-metadata.json
+++ b/user/src/main/resources/META-INF/spring-configuration-metadata.json
@@ -1,0 +1,8 @@
+{
+  "properties": [
+    {
+      "name": "momukji.user.authCode",
+      "type": "java.lang.String"
+    }
+  ]
+}

--- a/user/src/main/resources/application.yml
+++ b/user/src/main/resources/application.yml
@@ -33,3 +33,7 @@ eureka:
     fetch-registry: true #클라이언트로써 eureka 서버에서 eureka 레지스트리 정보를 가져올지 여부를 설정
     service-url:
       default-zone: http://localhost:8761/eureka/ #유레카 서버에 해당하는 url을 써줘야 함. 
+
+momukji:
+  user:
+    authCode: code


### PR DESCRIPTION
* application.yml에 momukji.user.authCode 속성 추가
* GET /getUser 요청 파라미터에 authCode 추가
  * authCode가 application.yml의 authCode와 일치해야만 User를 반환하도록 함

closes #53 