### PR TITLE
feat : 토큰 유효성 검사 api 생성

### DIFF
--- a/auth/src/main/java/kr/flab/momukji/auth/config/SecurityConfig.java
+++ b/auth/src/main/java/kr/flab/momukji/auth/config/SecurityConfig.java
@@ -47,6 +47,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
             .authorizeRequests()
             .antMatchers("/api/authenticate").permitAll()
             .antMatchers("/api/signup").permitAll()
+            .antMatchers("/api/validate").permitAll()
             .antMatchers("/swagger-ui/**").permitAll()
             .antMatchers("/swagger-resources/**").permitAll()
 

--- a/auth/src/main/java/kr/flab/momukji/auth/controller/AuthController.java
+++ b/auth/src/main/java/kr/flab/momukji/auth/controller/AuthController.java
@@ -1,9 +1,9 @@
 package kr.flab.momukji.auth.controller;
 
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.bind.annotation.RequestHeader;
 
 import kr.flab.momukji.auth.dto.response.CommonResponse;
 
@@ -18,7 +18,7 @@ public class AuthController {
     private final JwtService jwtService;
     
     @PostMapping("/validate")
-    public CommonResponse checkValidate(@RequestHeader("Token") String token) {
+    public CommonResponse checkValidate(@RequestBody String token) {
         return jwtService.checkToken(token);
     }
 }

--- a/auth/src/main/java/kr/flab/momukji/auth/controller/AuthController.java
+++ b/auth/src/main/java/kr/flab/momukji/auth/controller/AuthController.java
@@ -1,0 +1,24 @@
+package kr.flab.momukji.auth.controller;
+
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.RequestHeader;
+
+import kr.flab.momukji.auth.dto.response.CommonResponse;
+
+import kr.flab.momukji.auth.service.JwtService;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class AuthController {
+
+    private final JwtService jwtService;
+    
+    @PostMapping("/validate")
+    public CommonResponse checkValidate(@RequestHeader("Token") String token) {
+        return jwtService.checkToken(token);
+    }
+}

--- a/auth/src/main/java/kr/flab/momukji/auth/controller/AuthController.java
+++ b/auth/src/main/java/kr/flab/momukji/auth/controller/AuthController.java
@@ -5,6 +5,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import kr.flab.momukji.auth.dto.request.ValidateDto;
 import kr.flab.momukji.auth.dto.response.CommonResponse;
 
 import kr.flab.momukji.auth.service.JwtService;
@@ -18,7 +19,7 @@ public class AuthController {
     private final JwtService jwtService;
     
     @PostMapping("/validate")
-    public CommonResponse checkValidate(@RequestBody String token) {
-        return jwtService.checkToken(token);
+    public CommonResponse checkValidate(@RequestBody ValidateDto validateDto) {
+        return jwtService.checkToken(validateDto.getToken());
     }
 }

--- a/auth/src/main/java/kr/flab/momukji/auth/dto/request/ValidateDto.java
+++ b/auth/src/main/java/kr/flab/momukji/auth/dto/request/ValidateDto.java
@@ -1,0 +1,11 @@
+package kr.flab.momukji.auth.dto.request;
+
+import javax.validation.constraints.NotNull;
+
+import lombok.Getter;
+
+@Getter
+public class ValidateDto {
+    @NotNull
+    private String token;
+}

--- a/auth/src/main/java/kr/flab/momukji/auth/dto/response/CommonResponse.java
+++ b/auth/src/main/java/kr/flab/momukji/auth/dto/response/CommonResponse.java
@@ -1,0 +1,10 @@
+package kr.flab.momukji.auth.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+public class CommonResponse {
+    public ResultCode resultCode = ResultCode.SUCCESS;
+}

--- a/auth/src/main/java/kr/flab/momukji/auth/dto/response/ResultCode.java
+++ b/auth/src/main/java/kr/flab/momukji/auth/dto/response/ResultCode.java
@@ -1,0 +1,14 @@
+package kr.flab.momukji.auth.dto.response;
+
+import lombok.Getter;
+
+@Getter
+public enum ResultCode {
+    SUCCESS("성공"),VALID("유효한 토큰"), INVALID("잘못된 토큰");
+
+    private final String message;
+
+    private ResultCode(String message) {
+        this.message = message;
+    }
+}

--- a/auth/src/main/java/kr/flab/momukji/auth/dto/response/ResultCode.java
+++ b/auth/src/main/java/kr/flab/momukji/auth/dto/response/ResultCode.java
@@ -4,7 +4,7 @@ import lombok.Getter;
 
 @Getter
 public enum ResultCode {
-    SUCCESS("성공"), VALID("유효한 토큰"), INVALID("잘못된 토큰");
+    SUCCESS("성공"), VALID_TOKEN("유효한 토큰"), INVALID_TOKEN("잘못된 토큰");
 
     private final String message;
 

--- a/auth/src/main/java/kr/flab/momukji/auth/dto/response/ResultCode.java
+++ b/auth/src/main/java/kr/flab/momukji/auth/dto/response/ResultCode.java
@@ -4,7 +4,7 @@ import lombok.Getter;
 
 @Getter
 public enum ResultCode {
-    SUCCESS("성공"),VALID("유효한 토큰"), INVALID("잘못된 토큰");
+    SUCCESS("성공"), VALID("유효한 토큰"), INVALID("잘못된 토큰");
 
     private final String message;
 

--- a/auth/src/main/java/kr/flab/momukji/auth/dto/validate.java
+++ b/auth/src/main/java/kr/flab/momukji/auth/dto/validate.java
@@ -1,5 +1,0 @@
-package kr.flab.momukji.auth.dto;
-
-public class validate {
-    private String token;
-}

--- a/auth/src/main/java/kr/flab/momukji/auth/dto/validate.java
+++ b/auth/src/main/java/kr/flab/momukji/auth/dto/validate.java
@@ -1,0 +1,5 @@
+package kr.flab.momukji.auth.dto;
+
+public class validate {
+    private String token;
+}

--- a/auth/src/main/java/kr/flab/momukji/auth/service/JwtService.java
+++ b/auth/src/main/java/kr/flab/momukji/auth/service/JwtService.java
@@ -1,0 +1,24 @@
+package kr.flab.momukji.auth.service;
+
+import org.springframework.stereotype.Service;
+import kr.flab.momukji.auth.dto.response.CommonResponse;
+import kr.flab.momukji.auth.dto.response.ResultCode;
+import kr.flab.momukji.auth.jwt.TokenProvider;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class JwtService {
+
+    private final TokenProvider tokenProvider;
+
+    public CommonResponse checkToken(String token) {
+
+        if(!tokenProvider.validateToken(token)) {
+            return new CommonResponse(ResultCode.INVALID);
+        }
+
+        return new CommonResponse(ResultCode.VALID);
+    }
+    
+}

--- a/auth/src/main/java/kr/flab/momukji/auth/service/JwtService.java
+++ b/auth/src/main/java/kr/flab/momukji/auth/service/JwtService.java
@@ -1,6 +1,7 @@
 package kr.flab.momukji.auth.service;
 
 import org.springframework.stereotype.Service;
+
 import kr.flab.momukji.auth.dto.response.CommonResponse;
 import kr.flab.momukji.auth.dto.response.ResultCode;
 import kr.flab.momukji.auth.jwt.TokenProvider;

--- a/auth/src/main/java/kr/flab/momukji/auth/service/JwtService.java
+++ b/auth/src/main/java/kr/flab/momukji/auth/service/JwtService.java
@@ -15,10 +15,10 @@ public class JwtService {
     public CommonResponse checkToken(String token) {
 
         if(!tokenProvider.validateToken(token)) {
-            return new CommonResponse(ResultCode.INVALID);
+            return new CommonResponse(ResultCode.INVALID_TOKEN);
         }
 
-        return new CommonResponse(ResultCode.VALID);
+        return new CommonResponse(ResultCode.VALID_TOKEN);
     }
     
 }


### PR DESCRIPTION
* 토큰 유효성 검사 api 생성
 -- 기존의 tokenProvider의 validateToken을 적용함
 -- validateToken 결과에 따라 VALID 또는 INVALID을 반환하게 됨. 
 -- [auth]의 authenticate 즉, 토큰 생성하는 api 구축 후  해당 api가 제대로 작동되는지 테스트 해야함. 